### PR TITLE
Implement admin for access control

### DIFF
--- a/app/Http/Middleware/IsAdminMiddleware.php
+++ b/app/Http/Middleware/IsAdminMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsAdminMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (auth()->check() && auth()->user()->is_admin) {
+            return $next($request);
+        }
+        abort(Response::HTTP_FORBIDDEN);
+    }
+}

--- a/app/Livewire/Posts/CreatePost.php
+++ b/app/Livewire/Posts/CreatePost.php
@@ -18,6 +18,7 @@ class CreatePost extends Component
 
     public function store(): void
     {
+        $this->authorize('create', Post::class);
         $this->validate();
         try {
             $post = Post::create([

--- a/app/Livewire/Posts/EditPost.php
+++ b/app/Livewire/Posts/EditPost.php
@@ -32,6 +32,7 @@ class EditPost extends Component
 
     public function update(): void
     {
+        $this->authorize('update', $this->post);
         $rules = $this->rules;
         // Ignore slug so we can update other details and keep it the same
         $rules['slug'] = ['required', 'max:255',

--- a/app/Livewire/Posts/PostCell.php
+++ b/app/Livewire/Posts/PostCell.php
@@ -16,6 +16,7 @@ class PostCell extends Component
 
     public function delete(): void
     {
+        $this->authorize('delete', $this->post);
         if (!$this->post->deleteContent()) {
             $this->error("Server error writing post content to file");
             return;

--- a/app/Policies/PostPolicy.php
+++ b/app/Policies/PostPolicy.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+/**
+ * Post policy is quite simple at the moment: any users can view any posts, and admins can use any CRUD operation on
+ * all posts.
+ */
+class PostPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Post $post): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return isset($user) && $user->is_admin;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Post $post): bool
+    {
+        return isset($user) && $user->is_admin;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Post $post): bool
+    {
+        return isset($user) && $user->is_admin;
+    }
+}

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -21,9 +21,9 @@ class PostFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => fake()->realText(255),
-            'slug' => fake()->unique()->realText(255),
-            'summary' => fake()->realText(255)
+            'title' => fake()->realText(20),
+            'slug' => fake()->unique()->realText(20),
+            'summary' => fake()->realText(20)
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -41,4 +41,11 @@ class UserFactory extends Factory
             'email_verified_at' => null,
         ]);
     }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_admin' => true,
+        ]);
+    }
 }

--- a/database/migrations/2025_07_28_143200_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_07_28_143200_add_is_admin_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <ini name="memory_limit" value="256M"/>
     </php>
 </phpunit>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\IsAdminMiddleware;
 use App\Livewire\Posts\CreatePost;
 use App\Livewire\Posts\EditPost;
 use App\Livewire\Posts\PostIndex;
@@ -19,10 +20,12 @@ Route::middleware(['auth'])->group(function () {
     Route::get('settings/password', Password::class)->name('settings.password');
     Route::get('settings/appearance', Appearance::class)->name('settings.appearance');
 
-    Route::view('management', 'private.dashboard')->name('dashboard');
-    Route::get('management/blog', PostIndex::class)->name('management.blog.index');
-    Route::get('management/blog/create', CreatePost::class)->name('management.blog.create');
-    Route::get('management/blog/edit/{slug}', EditPost::class)->name('management.blog.edit');
+    Route::middleware(IsAdminMiddleware::class)->group(function () {
+        Route::view('management', 'private.dashboard')->name('dashboard');
+        Route::get('management/blog', PostIndex::class)->name('management.blog.index');
+        Route::get('management/blog/create', CreatePost::class)->name('management.blog.create');
+        Route::get('management/blog/edit/{slug}', EditPost::class)->name('management.blog.edit');
+    });
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/ManagementTest.php
+++ b/tests/Feature/ManagementTest.php
@@ -6,7 +6,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class DashboardTest extends TestCase
+class ManagementTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -15,10 +15,18 @@ class DashboardTest extends TestCase
         $this->get('/management')->assertRedirect('/login');
     }
 
-    public function test_authenticated_users_can_visit_the_dashboard(): void
+    public function test_non_admin_users_cannot_access_the_page(): void
     {
-        $this->actingAs($user = User::factory()->create());
+        $this->actingAs(User::factory()->create());
+
+        $this->get('/management')->assertStatus(403);
+    }
+
+    public function test_admin_users_can_visit_the_page(): void
+    {
+        $this->actingAs(User::factory()->admin()->create());
 
         $this->get('/management')->assertStatus(200);
     }
+
 }

--- a/tests/Feature/Post/CreatePostTest.php
+++ b/tests/Feature/Post/CreatePostTest.php
@@ -18,23 +18,46 @@ class CreatePostTest extends TestCase
         $this->get('/management/blog/create')->assertRedirect('/login');
     }
 
-    public function test_authenticated_users_can_visit_the_page(): void
+    public function test_non_admin_users_cannot_access_the_page(): void
     {
         $this->actingAs(User::factory()->create());
+
+        $this->get('/management/blog/create')->assertStatus(403);
+    }
+
+    public function test_admin_users_can_visit_the_page(): void
+    {
+        $this->actingAs(User::factory()->admin()->create());
 
         $this->get('/management/blog/create')->assertStatus(200);
     }
 
     public function test_page_contains_livewire_component(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $this->get('/management/blog/create')->assertSeeLivewire(CreatePost::class);
     }
 
-    public function test_cannot_create_post_without_title(): void
+    public function test_guests_cannot_create_post(): void
+    {
+        Livewire::test(CreatePost::class)
+            ->call('store')
+            ->assertStatus(403);
+    }
+
+    public function test_non_admin_users_cannot_create_post(): void
     {
         $this->actingAs(User::factory()->create());
+
+        Livewire::test(CreatePost::class)
+            ->call('store')
+            ->assertStatus(403);
+    }
+
+    public function test_cannot_create_post_without_title(): void
+    {
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('slug', 'test-slug')
@@ -47,7 +70,7 @@ class CreatePostTest extends TestCase
 
     public function test_cannot_create_post_without_slug(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')
@@ -60,7 +83,7 @@ class CreatePostTest extends TestCase
 
     public function test_cannot_create_post_with_used_slug(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')
@@ -83,7 +106,7 @@ class CreatePostTest extends TestCase
 
     public function test_cannot_create_post_without_summary(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')
@@ -96,7 +119,7 @@ class CreatePostTest extends TestCase
 
     public function test_cannot_create_post_without_content(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')
@@ -110,7 +133,7 @@ class CreatePostTest extends TestCase
     public function test_post_creation_adds_database_row(): void
     {
         Storage::fake('blog');
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')
@@ -131,7 +154,7 @@ class CreatePostTest extends TestCase
     public function test_redirects_on_successful_post_creation(): void
     {
         Storage::fake('blog');
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $response = Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')
@@ -148,7 +171,7 @@ class CreatePostTest extends TestCase
     public function test_post_content_is_written_to_disk(): void
     {
         Storage::fake('blog');
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         Livewire::test(CreatePost::class)
             ->set('title', 'Test Title')

--- a/tests/Feature/Post/PostCellTest.php
+++ b/tests/Feature/Post/PostCellTest.php
@@ -14,9 +14,27 @@ class PostCellTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_delete_removes_database_row(): void
+    public function test_guests_cannot_delete_a_post(): void
     {
-        $this->actingAs(User::factory()->create());
+        $post = Post::factory()->create();
+
+        Livewire::test(PostCell::class, ['post' => $post])
+            ->call('delete')
+            ->assertStatus(403);
+    }
+
+    public function test_non_admin_users_cannot_delete_a_post(): void
+    {
+        $post = Post::factory()->create();
+
+        Livewire::test(PostCell::class, ['post' => $post])
+            ->call('delete')
+            ->assertStatus(403);
+    }
+
+    public function test_deleting_post_removes_the_database_row(): void
+    {
+        $this->actingAs(User::factory()->admin()->create());
         $post = Post::factory()->create();
 
         Livewire::test(PostCell::class, ['post' => $post])
@@ -25,9 +43,9 @@ class PostCellTest extends TestCase
         $this->assertDatabaseMissing('posts', ['id' => $post->id]);
     }
 
-    public function test_delete_removes_content_file(): void
+    public function test_deleting_post_removes_content_file(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
         $post = Post::factory()->create();
         $post->writeContent('Some test content...');
 

--- a/tests/Feature/Post/PostIndexTest.php
+++ b/tests/Feature/Post/PostIndexTest.php
@@ -19,23 +19,30 @@ class PostIndexTest extends TestCase
         $this->get('/management/blog')->assertRedirect('/login');
     }
 
-    public function test_authenticated_users_can_visit_the_page(): void
+    public function test_non_admin_users_cannot_access_the_page(): void
     {
         $this->actingAs(User::factory()->create());
+
+        $this->get('/management/blog')->assertStatus(403);
+    }
+
+    public function test_admin_users_can_visit_the_page(): void
+    {
+        $this->actingAs(User::factory()->admin()->create());
 
         $this->get('/management/blog')->assertStatus(200);
     }
 
     public function test_page_contains_livewire_component(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $this->get('/management/blog')->assertSeeLivewire(PostIndex::class);
     }
 
     public function test_posts_passed_to_view(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
         Post::factory()->count(3)->create();
 
         Livewire::test(PostIndex::class)
@@ -46,14 +53,14 @@ class PostIndexTest extends TestCase
 
     public function test_page_doesnt_contain_cell_component_when_no_posts(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
 
         $this->get('/management/blog')->assertDontSeeLivewire(PostCell::class);
     }
 
     public function test_page_contains_cell_component_when_posts(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
         Post::factory()->create();
 
         $this->get('/management/blog')->assertSeeLivewire(PostCell::class);
@@ -61,7 +68,7 @@ class PostIndexTest extends TestCase
 
     public function test_deletion_updates_view(): void
     {
-        $this->actingAs(User::factory()->create());
+        $this->actingAs(User::factory()->admin()->create());
         $post = Post::factory()->create();
 
         Livewire::test(PostCell::class, ['post' => $post])


### PR DESCRIPTION
Implements the feature specification closing #4. This adds: 

- Database migration for an `is_admin` field in the users table
- Middleware for checking whether a user is an admin using this field
- Restrictions on routes to management pages that require the admin middleware
- A post policy, in which: any user can view posts, but only admins can manage posts
- Updates to feature tests to reflect this, and new tests to ensure the middleware/policy works as intended