### PR TITLE
Implement blog post page

### DIFF
--- a/app/Livewire/Blog/ShowPost.php
+++ b/app/Livewire/Blog/ShowPost.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Livewire\Blog;
+
+use App\Models\Post;
+use Livewire\Component;
+
+class ShowPost extends Component
+{
+    public $post;
+
+    public function render()
+    {
+        return view('livewire.blog.show-post')->layout('components.layouts.public.page');
+    }
+
+    public function mount(string $slug)
+    {
+        $this->post = Post::all()->where('slug', $slug)->first();
+        if (!isset($this->post)) {
+            abort(404);
+        }
+    }
+}

--- a/app/Livewire/Blog/ShowPost.php
+++ b/app/Livewire/Blog/ShowPost.php
@@ -21,4 +21,18 @@ class ShowPost extends Component
             abort(404);
         }
     }
+
+    public function delete(): void
+    {
+        $this->authorize('delete', $this->post);
+        if (!$this->post->deleteContent()) {
+            session()->flash('error', 'Server error deleting post content');
+            return;
+        }
+        if (!$this->post->delete()) {
+            session()->flash('error', 'Server error deleting post from database');
+            return;
+        }
+        $this->redirectRoute('blog.index');
+    }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
+use Parsedown;
 
 class Post extends Model
 {
@@ -26,6 +27,11 @@ class Post extends Model
         return "$this->id/content.md";
     }
 
+    private function getContentPathHtml(): string
+    {
+        return "$this->id/content.html";
+    }
+
     public function readContent(): string|null
     {
         $path = $this->getContentPath();
@@ -35,13 +41,34 @@ class Post extends Model
     public function writeContent(string $content): bool
     {
         $path = $this->getContentPath();
-        return Storage::disk('blog')->put($path, $content);
+        if (!Storage::disk('blog')->put($path, $content)) {
+            return false;
+        }
+        $html = $this->convertToHtml($content);
+        $path = $this->getContentPathHtml();
+        return Storage::disk('blog')->put($path, $html);
     }
 
     public function deleteContent(): bool
     {
         $path = $this->getContentPath();
-        return Storage::disk('blog')->delete($path);
+        $pathHtml = $this->getContentPathHtml();
+        return Storage::disk('blog')->delete($path) && Storage::disk('blog')->delete($pathHtml);
+    }
+
+    public function readAsHtml(): string|null
+    {
+        $path = $this->getContentPathHtml();
+        if (!Storage::disk('blog')->exists($path)) {
+            $html = $this->convertToHtml($this->readContent());
+            Storage::disk('blog')->put($path, $html);
+            return $html;
+        }
+        return Storage::disk('blog')->get($path);
+    }
+
+    private function convertToHtml(string $content): string {
+        return Parsedown::instance()->text($content);
     }
 
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -60,7 +60,11 @@ class Post extends Model
     {
         $path = $this->getContentPathHtml();
         if (!Storage::disk('blog')->exists($path)) {
-            $html = $this->convertToHtml($this->readContent());
+            $content = $this->readContent();
+            if (!$content) {
+                return null;
+            }
+            $html = $this->convertToHtml($content);
             Storage::disk('blog')->put($path, $html);
             return $html;
         }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Blade::if('isAdmin', function () {
+            return auth()->check() && auth()->user()->is_admin;
+        });
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "erusev/parsedown": "^1.7",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "livewire/flux": "^2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9929ae0f39b99702c171f9c9695fdcb9",
+    "content-hash": "cdfdfd57e9dd3592b7339fbe69f00c51",
     "packages": [
         {
             "name": "brick/math",
@@ -509,6 +509,56 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/erusev/parsedown/issues",
+                "source": "https://github.com/erusev/parsedown/tree/1.7.x"
+            },
+            "time": "2019-12-30T22:54:17+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -26,6 +26,8 @@
     --color-accent: var(--color-sky-600);
     --color-accent-content: var(--color-sky-600);
     --color-accent-foreground: var(--color-white);
+
+    --color-divider: var(--color-zinc-200);
 }
 
 @layer theme {
@@ -33,6 +35,8 @@
         --color-accent: var(--color-sky-600);
         --color-accent-content: var(--color-sky-400);
         --color-accent-foreground: var(--color-white);
+
+        --color-divider: var(--color-zinc-700);
     }
 }
 
@@ -88,15 +92,78 @@ select:focus[data-flux-control] {
     width: calc(var(--spacing) * 128);
 }
 
-#content {
+#blog-body-container {
+    overflow: hidden;
+
     h1 {
-        margin-top: calc(var(--spacing) * 2);
+        font-size: var(--text-4xl);
+    }
+
+    h2 {
+        font-size: var(--text-3xl);
+    }
+
+    h3 {
+        font-size: var(--text-2xl);
+    }
+
+    h4 {
         font-size: var(--text-xl);
+    }
+
+    h5 {
+        font-size: var(--text-lg);
+    }
+
+    hr {
+        border-color: var(--color-divider);
+    }
+
+    h1, h2 {
+        border-bottom: 1px solid var(--color-divider);
+    }
+
+    h1, h2, ul, ol {
+        margin-top: calc(var(--spacing) * 2);
+        margin-bottom: calc(var(--spacing) * 2);
+    }
+
+    h3, h4, h5, h6, table {
+        margin-top: var(--spacing);
+        margin-bottom: var(--spacing);
+    }
+
+    h1, h2, h3, h4, h5, h6 {
         font-weight: var(--font-weight-bold);
+    }
+
+    ul, ol {
+        list-style-position: inside;
+        font-weight: var(--font-weight-normal);
     }
 
     ul {
         list-style-type: disc;
-        list-style-position: inside;
+    }
+
+    ol {
+        list-style-type: decimal;
+    }
+
+    a {
+        color: var(--color-accent);
+        text-decoration: underline;
+    }
+
+    table, th, td {
+        border: 1px solid var(--color-divider);
+    }
+
+    th, td {
+        padding: var(--spacing) calc(2 * var(--spacing));
+    }
+
+    code {
+        font-size: var(--text-sm);
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -87,3 +87,16 @@ select:focus[data-flux-control] {
 .w-128 {
     width: calc(var(--spacing) * 128);
 }
+
+#content {
+    h1 {
+        margin-top: calc(var(--spacing) * 2);
+        font-size: var(--text-xl);
+        font-weight: var(--font-weight-bold);
+    }
+
+    ul {
+        list-style-type: disc;
+        list-style-position: inside;
+    }
+}

--- a/resources/views/components/layouts/public/header.blade.php
+++ b/resources/views/components/layouts/public/header.blade.php
@@ -13,7 +13,7 @@
                 <flux:navbar.item class="[&>div>svg]:size-5" icon="folder-git-2" href="#" :label="__('Portfolio')">
                     {{ __('Portfolio') }}
                 </flux:navbar.item>
-                <flux:navbar.item class="[&>div>svg]:size-5" icon="book-open-text" href="{{ route('blog.index') }}" :current="request()->routeIs('blog.index')" :label="__('Blog')">
+                <flux:navbar.item class="[&>div>svg]:size-5" icon="book-open-text" href="{{ route('blog.index') }}" :current="request()->routeIs('blog.*')" :label="__('Blog')">
                     {{ __('Blog') }}
                 </flux:navbar.item>
             </flux:navbar>

--- a/resources/views/livewire/blog/blog-index.blade.php
+++ b/resources/views/livewire/blog/blog-index.blade.php
@@ -5,7 +5,7 @@
         <flux:heading size="xl" class="pb-4">Blog</flux:heading>
         @foreach($posts as $post)
             <article class="px-2 py-3 border-b border-zinc-300 dark:border-zinc-700">
-                <flux:heading class="text-xl mb-0.5!">{{ $post->title }}</flux:heading>
+                <flux:heading class="text-xl mb-0.5!"><a href="{{ route('blog.show', $post->slug) }}">{{ $post->title }}</a></flux:heading>
                 <flux:subheading size="sm">Published on {{ $post->created_at->format('j F Y') }}</flux:subheading>
                 <flux:subheading size="md" class="mt-1.5 text-zinc-700 dark:text-zinc-50">{{ $post->summary }}</flux:subheading>
             </article>

--- a/resources/views/livewire/blog/blog-index.blade.php
+++ b/resources/views/livewire/blog/blog-index.blade.php
@@ -1,10 +1,25 @@
 <div class="flex justify-center h-full">
     <div class="flex flex-col lg:block mt-10 w-full max-w-6xl
-                    relative mx-5 lg:mx-10 xl:mx-auto px-10 pt-8 rounded-md border
+                    relative mx-5 lg:mx-10 xl:mx-auto px-10 py-8 rounded-md border
                     bg-zinc-50 dark:bg-zinc-900 border-zinc-200 dark:border-zinc-600">
+        @isAdmin
+        <div id="admin-panel" class="flex justify-between items-center pb-1 mb-3 w-full border-b border-b-divider">
+            <flux:subheading size="sm" class="text-zinc-400 uppercase">Admin</flux:subheading>
+            <div class="flex gap-1">
+                <flux:button iconLeading="eye-slash" class="h-5 text-sm" onclick="hideAdminPanel()">Hide</flux:button>
+                <flux:button iconLeading="pencil" class="h-5 text-sm" href="{{ route('management.blog.index') }}">Edit</flux:button>
+                <flux:button iconLeading="plus" class="h-5 text-sm" href="{{ route('management.blog.create') }}">Add</flux:button>
+            </div>
+            <script>
+                function hideAdminPanel() {
+                    document.getElementById('admin-panel').remove();
+                }
+            </script>
+        </div>
+        @endisAdmin
         <flux:heading size="xl" class="pb-4">Blog</flux:heading>
         @foreach($posts as $post)
-            <article class="px-2 py-3 border-b border-zinc-300 dark:border-zinc-700">
+            <article class="px-2 py-3 border-b border-b-divider">
                 <flux:heading class="text-xl mb-0.5!"><a href="{{ route('blog.show', $post->slug) }}">{{ $post->title }}</a></flux:heading>
                 <flux:subheading size="sm">Published on {{ $post->created_at->format('j F Y') }}</flux:subheading>
                 <flux:subheading size="md" class="mt-1.5 text-zinc-700 dark:text-zinc-50">{{ $post->summary }}</flux:subheading>

--- a/resources/views/livewire/blog/show-post.blade.php
+++ b/resources/views/livewire/blog/show-post.blade.php
@@ -1,0 +1,13 @@
+<div class="flex justify-center h-full">
+    <div class="flex flex-col lg:block mt-10 w-full max-w-6xl
+                    relative mx-5 lg:mx-10 xl:mx-auto px-10 pt-8 rounded-md border
+                    bg-zinc-50 dark:bg-zinc-900 border-zinc-200 dark:border-zinc-600">
+        <flux:heading size="xl">{{ $post->title }}</flux:heading>
+
+        <div id="content"><!-- Content will be inserted here --></div>
+        <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
+        <script>
+            document.getElementById('content').innerHTML = marked.parse(`{{ $post->readContent()  }}`);
+        </script>
+    </div>
+</div>

--- a/resources/views/livewire/blog/show-post.blade.php
+++ b/resources/views/livewire/blog/show-post.blade.php
@@ -1,13 +1,28 @@
 <div class="flex justify-center h-full">
     <div class="flex flex-col lg:block mt-10 w-full max-w-6xl
-                    relative mx-5 lg:mx-10 xl:mx-auto px-10 pt-8 rounded-md border
+                    relative mx-5 lg:mx-10 xl:mx-auto px-10 py-8 rounded-md border
                     bg-zinc-50 dark:bg-zinc-900 border-zinc-200 dark:border-zinc-600">
-        <flux:heading size="xl">{{ $post->title }}</flux:heading>
+        @isAdmin
+        <div id="admin-panel" class="flex justify-between items-center pb-1 mb-3 w-full border-b border-b-divider">
+            <flux:subheading size="sm" class="text-zinc-400 uppercase">Admin</flux:subheading>
+            <div class="flex gap-1">
+                <flux:button iconLeading="eye-slash" class="h-5 text-sm" onclick="hideAdminPanel()">Hide</flux:button>
+                <flux:button iconLeading="pencil" class="h-5 text-sm" href="{{ route('management.blog.edit', $post->slug) }}">Edit</flux:button>
+                <flux:button iconLeading="trash" title="Delete" variant="danger" wire:click="delete" wire:confirm="Are you sure you want to delete this post?">Delete</flux:button>
+            </div>
+            <script>
+                function hideAdminPanel() {
+                    document.getElementById('admin-panel').remove();
+                }
+            </script>
+        </div>
+        @endisAdmin
 
-        <div id="content"><!-- Content will be inserted here --></div>
-        <script src="https://cdn.jsdelivr.net/npm/marked/lib/marked.umd.js"></script>
-        <script>
-            document.getElementById('content').innerHTML = marked.parse(`{{ $post->readContent()  }}`);
-        </script>
+        <flux:heading class="text-4xl! font-bold!">{{ $post->title }}</flux:heading>
+        <flux:subheading size="md" class="mb-3">Published on {{ $post->created_at->format('j F Y') }}</flux:subheading>
+        <hr class="border-divider mb-3" />
+        <div id="blog-body-container">
+            {!! $post->readAsHtml() !!}
+        </div>
     </div>
 </div>

--- a/resources/views/livewire/posts/post-cell.blade.php
+++ b/resources/views/livewire/posts/post-cell.blade.php
@@ -8,7 +8,7 @@
     <div class="flex items-center justify-center flex-col-reverse">
         <div class="flex gap-2">
             @php($modalName = 'confirm-post-' . $post->id . '-deletion')
-            <flux:button href="#" class="hover:cursor-pointer">View</flux:button>
+            <flux:button href="{{ route('blog.show', $post->slug) }}" class="hover:cursor-pointer">View</flux:button>
             <flux:button href="{{ route('management.blog.edit', $post->slug) }}" class="hover:cursor-pointer">Edit</flux:button>
 
             <flux:modal.trigger name="{{ $modalName }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\IsAdminMiddleware;
 use App\Livewire\Blog\BlogIndex;
+use App\Livewire\Blog\ShowPost;
 use App\Livewire\Posts\CreatePost;
 use App\Livewire\Posts\EditPost;
 use App\Livewire\Posts\PostIndex;
@@ -18,6 +19,7 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('blog', BlogIndex::class)->name('blog.index');
+Route::get('blog/{slug}', ShowPost::class)->name('blog.show');
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');

--- a/tests/Feature/Blog/BlogIndexTest.php
+++ b/tests/Feature/Blog/BlogIndexTest.php
@@ -40,4 +40,23 @@ class BlogIndexTest extends TestCase
             ->assertSee('Published on ' . $post->created_at->format('j F Y'))
             ->assertSee('Test summary');
     }
+
+    public function test_guests_cannot_see_admin_panel(): void
+    {
+        $this->get('/blog')->assertDontSeeHtml('id="admin-panel"');
+    }
+
+    public function test_non_admin_users_cannot_see_admin_panel(): void
+    {
+        $this->actingAsUser();
+
+        $this->get('/blog')->assertDontSeeHtml('id="admin-panel"');
+    }
+
+    public function test_admins_can_see_admin_panel(): void
+    {
+        $this->actingAsAdmin();
+
+        $this->get('/blog')->assertSeeHtml('id="admin-panel"');
+    }
 }

--- a/tests/Feature/Blog/BlogIndexTest.php
+++ b/tests/Feature/Blog/BlogIndexTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Tests\Feature;
+namespace Feature\Blog;
 
 use App\Livewire\Blog\BlogIndex;
 use App\Models\Post;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class BlogTest extends TestCase
+class BlogIndexTest extends TestCase
 {
     use RefreshDatabase;
 
     public function test_returns_a_successful_response(): void
     {
-        $this->get('/blog')->assertStatus(200);
+        $this->get('/blog')->assertSuccessful();
     }
 
     public function test_contains_blog_livewire_component(): void

--- a/tests/Feature/Blog/ShowBlogTest.php
+++ b/tests/Feature/Blog/ShowBlogTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Blog;
+
+use App\Livewire\Blog\ShowPost;
+use App\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShowBlogTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_not_found_when_post_doesnt_exist(): void
+    {
+        $this->get('/blog/some-nonexistent-post')->assertNotFound();
+    }
+
+    public function test_returns_success_when_post_exist(): void
+    {
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertSuccessful();
+    }
+
+    public function test_page_contains_livewire_component(): void
+    {
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertSeeLivewire(ShowPost::class);
+    }
+
+    public function test_page_displays_title(): void
+    {
+        Post::factory()->create(['title' => 'A test title', 'slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertSee('A test title');
+    }
+
+    public function test_page_displays_date_published(): void
+    {
+        $post = Post::factory()->create(['slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertSee('Published on ' . $post->created_at->format('j F Y'));
+    }
+
+    public function test_page_displays_content(): void
+    {
+        $post = Post::factory()->create(['slug' => 'test-slug']);
+        $post->writeContent('Some test content which we can hopefully see...');
+
+        $this->get('/blog/test-slug')->assertSee('Some test content which we can hopefully see...');
+    }
+
+}

--- a/tests/Feature/Blog/ShowBlogTest.php
+++ b/tests/Feature/Blog/ShowBlogTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Blog;
 use App\Livewire\Blog\ShowPost;
 use App\Models\Post;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class ShowBlogTest extends TestCase
@@ -18,6 +19,7 @@ class ShowBlogTest extends TestCase
 
     public function test_returns_success_when_post_exist(): void
     {
+        Storage::fake('blog');
         Post::factory()->create(['slug' => 'test-slug']);
 
         $this->get('/blog/test-slug')->assertSuccessful();
@@ -25,6 +27,7 @@ class ShowBlogTest extends TestCase
 
     public function test_page_contains_livewire_component(): void
     {
+        Storage::fake('blog');
         Post::factory()->create(['slug' => 'test-slug']);
 
         $this->get('/blog/test-slug')->assertSeeLivewire(ShowPost::class);
@@ -32,6 +35,7 @@ class ShowBlogTest extends TestCase
 
     public function test_page_displays_title(): void
     {
+        Storage::fake('blog');
         Post::factory()->create(['title' => 'A test title', 'slug' => 'test-slug']);
 
         $this->get('/blog/test-slug')->assertSee('A test title');
@@ -39,6 +43,7 @@ class ShowBlogTest extends TestCase
 
     public function test_page_displays_date_published(): void
     {
+        Storage::fake('blog');
         $post = Post::factory()->create(['slug' => 'test-slug']);
 
         $this->get('/blog/test-slug')->assertSee('Published on ' . $post->created_at->format('j F Y'));
@@ -46,6 +51,7 @@ class ShowBlogTest extends TestCase
 
     public function test_page_displays_content(): void
     {
+        Storage::fake('blog');
         $post = Post::factory()->create(['slug' => 'test-slug']);
         $post->writeContent('Some test content which we can hopefully see...');
 

--- a/tests/Feature/Blog/ShowBlogTest.php
+++ b/tests/Feature/Blog/ShowBlogTest.php
@@ -6,6 +6,7 @@ use App\Livewire\Blog\ShowPost;
 use App\Models\Post;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class ShowBlogTest extends TestCase
@@ -57,5 +58,49 @@ class ShowBlogTest extends TestCase
 
         $this->get('/blog/test-slug')->assertSee('Some test content which we can hopefully see...');
     }
+
+    public function test_guests_cannot_delete_a_post(): void
+    {
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        Livewire::test(ShowPost::class, ['slug' => 'test-slug'])
+            ->call('delete')
+            ->assertStatus(403);
+    }
+
+    public function test_non_admin_users_cannot_delete_a_post(): void
+    {
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        Livewire::test(ShowPost::class, ['slug' => 'test-slug'])
+            ->call('delete')
+            ->assertStatus(403);
+    }
+
+    public function test_deleting_post_removes_the_database_row(): void
+    {
+        $this->actingAsAdmin();
+        $post = Post::factory()->create(['slug' => 'test-slug']);
+
+        Livewire::test(ShowPost::class, ['slug' => 'test-slug'])
+            ->call('delete');
+
+        $this->assertDatabaseMissing('posts', ['id' => $post->id]);
+    }
+
+    public function test_deleting_post_removes_content_files(): void
+    {
+        Storage::fake('blog');
+        $this->actingAsAdmin();
+        $post = Post::factory()->create(['slug' => 'test-slug']);
+        $post->writeContent('Some test content...');
+
+        Livewire::test(ShowPost::class, ['slug' => 'test-slug'])
+            ->call('delete');
+
+        Storage::disk('blog')->assertMissing('1/content.md');
+        Storage::disk('blog')->assertMissing('1/content.html');
+    }
+
 
 }

--- a/tests/Feature/Blog/ShowBlogTest.php
+++ b/tests/Feature/Blog/ShowBlogTest.php
@@ -59,6 +59,32 @@ class ShowBlogTest extends TestCase
         $this->get('/blog/test-slug')->assertSee('Some test content which we can hopefully see...');
     }
 
+    public function test_guests_cannot_see_admin_panel(): void
+    {
+        Storage::fake('blog');
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertDontSeeHtml('id="admin-panel"');
+    }
+
+    public function test_non_admin_users_cannot_see_admin_panel(): void
+    {
+        $this->actingAsUser();
+        Storage::fake('blog');
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertDontSeeHtml('id="admin-panel"');
+    }
+
+    public function test_admins_can_see_admin_panel(): void
+    {
+        $this->actingAsAdmin();
+        Storage::fake('blog');
+        Post::factory()->create(['slug' => 'test-slug']);
+
+        $this->get('/blog/test-slug')->assertSeeHtml('id="admin-panel"');
+    }
+
     public function test_guests_cannot_delete_a_post(): void
     {
         Post::factory()->create(['slug' => 'test-slug']);

--- a/tests/Feature/Post/CreatePostTest.php
+++ b/tests/Feature/Post/CreatePostTest.php
@@ -184,6 +184,22 @@ class CreatePostTest extends TestCase
         $this->assertEquals('Some test content...', Storage::disk('blog')->get('1/content.md'));
     }
 
+    public function test_post_content_html_is_written_to_disk(): void
+    {
+        Storage::fake('blog');
+        $this->actingAsAdmin();
+
+        Livewire::test(CreatePost::class)
+            ->set('title', 'Test Title')
+            ->set('slug', 'test-slug')
+            ->set('summary', 'Test summary')
+            ->set('content', 'Some test content...')
+            ->call('store');
+
+        Storage::disk('blog')->assertExists('1/content.html');
+        $this->assertEquals('<p>Some test content...</p>', Storage::disk('blog')->get('1/content.html'));
+    }
+
     public function test_page_contains_attachment_manager(): void
     {
         $this->actingAsAdmin()->get('/management/blog/create')->assertSeeLivewire(AttachmentManager::class);

--- a/tests/Feature/Post/EditPostTest.php
+++ b/tests/Feature/Post/EditPostTest.php
@@ -197,6 +197,21 @@ class EditPostTest extends TestCase
         $this->assertEquals('Some modified test content...', Storage::disk('blog')->get('1/content.md'));
     }
 
+    public function test_modified_post_content_html_is_written_to_disk(): void
+    {
+        Storage::fake('blog');
+        $this->actingAsAdmin();
+        $post = Post::factory()->create();
+        $post->writeContent('Some test content...');
+
+        Livewire::test(EditPost::class, ['slug' => $post->slug])
+            ->set('content', 'Some modified test content...')
+            ->call('update');
+
+        Storage::disk('blog')->assertExists('1/content.html');
+        $this->assertEquals('<p>Some modified test content...</p>', Storage::disk('blog')->get('1/content.html'));
+    }
+
     public function test_page_contains_attachment_manager(): void
     {
         $this->actingAsAdmin()->get('/management/blog/create')->assertSeeLivewire(AttachmentManager::class);

--- a/tests/Feature/Post/PostCellTest.php
+++ b/tests/Feature/Post/PostCellTest.php
@@ -42,7 +42,7 @@ class PostCellTest extends TestCase
         $this->assertDatabaseMissing('posts', ['id' => $post->id]);
     }
 
-    public function test_deleting_post_removes_content_file(): void
+    public function test_deleting_post_removes_content_files(): void
     {
         Storage::fake('blog');
         $this->actingAsAdmin();
@@ -52,7 +52,8 @@ class PostCellTest extends TestCase
         Livewire::test(PostCell::class, ['post' => $post])
             ->call('delete');
 
-        Storage::disk('blog')->assertMissing('1.md');
+        Storage::disk('blog')->assertMissing('1/content.md');
+        Storage::disk('blog')->assertMissing('1/content.html');
     }
 
 }


### PR DESCRIPTION
Implement blog post page closing #13. Features: 

- Changes to Post model, making it convert any writes to HTML using Parsedown and store them alongside the markdown file
- Add blog post page, which displays this content HTML alongside the title of the post and the date it was published
- Created styles for the generated HTML
- Added admin panels which use a new `@isAdmin` blade directive to give admins quick access to add/edit/delete posts from the public pages
- Added feature tests for the above