### PR TITLE
Implement portfolio page

### DIFF
--- a/app/Livewire/Portfolio/PortfolioIndex.php
+++ b/app/Livewire/Portfolio/PortfolioIndex.php
@@ -17,6 +17,6 @@ class PortfolioIndex extends Component
     public function mount(): void
     {
         // Collect the project, ordered with most recent first
-        $this->projects = Project::all()->sortByDesc(['standout', 'created_at']);
+        $this->projects = Project::all()->sortBy('order_index');
     }
 }

--- a/app/Livewire/Portfolio/PortfolioIndex.php
+++ b/app/Livewire/Portfolio/PortfolioIndex.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\Portfolio;
+
+use App\Models\Project;
+use Livewire\Component;
+
+class PortfolioIndex extends Component
+{
+    public $projects;
+
+    public function render()
+    {
+        return view('livewire.portfolio.portfolio-index')->layout('components.layouts.public.page');
+    }
+
+    public function mount(): void
+    {
+        // Collect the project, ordered with most recent first
+        $this->projects = Project::all()->sortByDesc(['standout', 'created_at']);
+    }
+}

--- a/app/Livewire/Projects/ProjectIndex.php
+++ b/app/Livewire/Projects/ProjectIndex.php
@@ -3,6 +3,8 @@
 namespace App\Livewire\Projects;
 
 use App\Models\Project;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 class ProjectIndex extends Component
@@ -12,7 +14,30 @@ class ProjectIndex extends Component
 
     public function mount(): void
     {
-        $this->projects = Project::all();
+        $this->projects = Project::all()->sortBy('order_index');
+    }
+
+    #[On('update-project-order')]
+    public function updateOrder(array $ordering): void
+    {
+        $case = 'CASE';
+        for ($i = 0; $i < count($ordering); $i++) {
+            $id = $ordering[$i];
+            // Verify IDs are integers
+            if (!is_int($id)) {
+                return;
+            }
+            $case .= " WHEN id = $id THEN $i ";
+        }
+        $case .= 'END';
+
+        // Batch update the order indexes
+        DB::table('projects')
+            ->whereIn('id', $ordering)
+            ->update(['order_index' => DB::raw($case)]);
+
+        // Workaround for project cells disappearing on update
+        $this->redirect(route('management.portfolio.index'));
     }
 
 }

--- a/database/migrations/2025_09_12_174007_add_order_index_to_projects_table.php
+++ b/database/migrations/2025_09_12_174007_add_order_index_to_projects_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->unsignedInteger('order_index')->after('standout')->default(0);
+        });
+        // Statement to set order_index to max(order) + 1, or 1 if no elements
+        DB::unprepared(
+            'CREATE TRIGGER set_order ' .
+            'AFTER INSERT ON projects ' .
+            'FOR EACH ROW ' .
+            'BEGIN ' .
+            'UPDATE projects SET order_index = COALESCE((SELECT MAX(order_index) FROM projects), 0) + 1 WHERE id = NEW.id;' .
+            'END;');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared('DROP TRIGGER set_order');
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('order_index');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -167,3 +167,11 @@ select:focus[data-flux-control] {
         font-size: var(--text-sm);
     }
 }
+
+.masonry-sizer, .project {
+    width: 33.3333%;
+}
+
+.standout {
+    width: 66.666%;
+}

--- a/resources/views/components/layouts/public/header.blade.php
+++ b/resources/views/components/layouts/public/header.blade.php
@@ -10,7 +10,7 @@
             <flux:spacer />
 
             <flux:navbar class="me-1.5 space-x-0.5 rtl:space-x-reverse py-0!">
-                <flux:navbar.item class="[&>div>svg]:size-5" icon="folder-git-2" href="#" :label="__('Portfolio')">
+                <flux:navbar.item class="[&>div>svg]:size-5" icon="folder-git-2" href="{{ route('portfolio.index') }}" :current="request()->routeIs('portfolio.*')" :label="__('Portfolio')">
                     {{ __('Portfolio') }}
                 </flux:navbar.item>
                 <flux:navbar.item class="[&>div>svg]:size-5" icon="book-open-text" href="{{ route('blog.index') }}" :current="request()->routeIs('blog.*')" :label="__('Blog')">

--- a/resources/views/livewire/portfolio/portfolio-index.blade.php
+++ b/resources/views/livewire/portfolio/portfolio-index.blade.php
@@ -1,0 +1,52 @@
+<div class="flex justify-center h-full">
+    <div class="flex flex-col lg:block mt-10 w-full max-w-6xl
+                    relative mx-5 lg:mx-10 xl:mx-auto px-10 py-8 rounded-md border
+                    bg-zinc-50 dark:bg-zinc-900 border-zinc-200 dark:border-zinc-600">
+        @isAdmin
+        <div id="admin-panel" class="flex justify-between items-center pb-1 mb-3 w-full border-b border-b-divider">
+            <flux:subheading size="sm" class="text-zinc-400 uppercase">Admin</flux:subheading>
+            <div class="flex gap-1">
+                <flux:button iconLeading="eye-slash" class="h-5 text-sm" onclick="hideAdminPanel()">Hide</flux:button>
+                <flux:button iconLeading="pencil" class="h-5 text-sm" href="{{ route('management.portfolio.index') }}">Edit</flux:button>
+                <flux:button iconLeading="plus" class="h-5 text-sm" href="{{ route('management.portfolio.create') }}">Add</flux:button>
+            </div>
+            <script>
+                function hideAdminPanel() {
+                    document.getElementById('admin-panel').remove();
+                }
+            </script>
+        </div>
+        @endisAdmin
+        <flux:heading size="xl" class="pb-4">Portfolio</flux:heading>
+        <div class="project-container">
+            <div class="masonry-sizer w-[50%]! md:w-[33.3333%]!"></div>
+            @foreach($projects as $project)
+                <div @class(['project', 'w-[50%]! md:w-[33.3333%]!' => !$project->standout, 'w-full! md:w-[66.6666%]!' => $project->standout])>
+                    <article class="m-1 px-5 py-6 border border-divider rounded-lg">
+                        <div class="flex justify-between items-center gap-2">
+                            <flux:heading class="text-xl mb-0.5!">{{ $project->title }}</flux:heading>
+                            <a href="{{ $project->repo_link }}" target="_blank">
+                                <img src="/images/brands/github-mark.png" alt="GitHub Icon" class="h-6 dark:hidden" />
+                                <img src="/images/brands/github-mark-white.png" alt="GitHub Icon" class="h-6 hidden dark:block" />
+                            </a>
+                        </div>
+                        <flux:subheading size="md" class="mt-1.5 text-zinc-700 dark:text-zinc-50">{{ $project->summary }}</flux:subheading>
+                        <img src="{{ $project->getCoverImagePath() }}" alt="Cover image" class="my-3 w-full"/>
+                        <flux:subheading size="md" class="mt-1.5 uppercase text-zinc-400">
+                            {{ str_replace(', ', ' | ', $project->tools) }}
+                        </flux:subheading>
+                    </article>
+                </div>
+            @endforeach
+        </div>
+    </div>
+    <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.js"></script>
+    <script>
+        let container = document.querySelector('.project-container');
+        new Masonry(container, {
+            itemSelector: '.project',
+            columnWidth: '.masonry-sizer',
+            percentPosition: true
+        });
+    </script>
+</div>

--- a/resources/views/livewire/posts/post-cell.blade.php
+++ b/resources/views/livewire/posts/post-cell.blade.php
@@ -1,4 +1,4 @@
-<article class="flex border-b pb-4 justify-between">
+<article class="flex border-b border-b-divider pb-4 justify-between">
     <div>
          <h3 class="text-lg font-semibold dark:text-zinc-100">
             <a href="{{ route('blog.show', $post->slug) }}" class="hover:underline">{{ $post->title }}</a>

--- a/resources/views/livewire/projects/edit-project.blade.php
+++ b/resources/views/livewire/projects/edit-project.blade.php
@@ -27,7 +27,7 @@
         <div class="flex items-center justify-between gap-2">
             <div class="flex gap-2">
                 <flux:button iconLeading="arrow-left" href="{{ route('management.portfolio.index') }}" class="hover:cursor-pointer">{{ __('Cancel') }}</flux:button>
-                <flux:button iconLeading="eye" href="#" class="hover:cursor-pointer">{{ __('View') }}</flux:button>
+                <flux:button iconLeading="eye" href="{{ route('portfolio.index') }}" class="hover:cursor-pointer">{{ __('View') }}</flux:button>
             </div>
             <div class="flex gap-2">
                 <flux:button iconLeading="bookmark" variant="primary" type="submit" class="hover:cursor-pointer">{{ __('Save') }}</flux:button>

--- a/resources/views/livewire/projects/project-cell.blade.php
+++ b/resources/views/livewire/projects/project-cell.blade.php
@@ -1,6 +1,6 @@
-<article class="flex border-b pb-4 justify-between">
+<article class="flex border-b pb-4 gap-2 justify-between">
     <div class="flex gap-4">
-        <img src="{{ $project->getCoverImagePath() }}" alt="Cover image" class="w-25 drop-shadow-xl" />
+        <img src="{{ $project->getCoverImagePath() }}" alt="Cover image" class="h-20 drop-shadow-xl" />
         <div class="flex justify-center flex-col">
             <flux:subheading size="lg" class="font-semibold text-gray-800 dark:text-zinc-100">
                 <a href="" class="hover:underline">{{ $project->title }}</a>
@@ -10,7 +10,6 @@
     </div>
     <div class="flex items-center justify-center flex-col-reverse">
         <div class="flex gap-2">
-            <flux:button iconLeading="eye" href="#" class="hover:cursor-pointer"/>
             <flux:button iconLeading="pencil" href="{{ route('management.portfolio.edit', $project->slug) }}" class="hover:cursor-pointer"/>
             <livewire:projects.delete-project-button :project="$project" redirect-to="management.portfolio.index" :text="false"/>
         </div>

--- a/resources/views/livewire/projects/project-cell.blade.php
+++ b/resources/views/livewire/projects/project-cell.blade.php
@@ -1,4 +1,4 @@
-<article class="flex border-b pb-4 gap-2 justify-between">
+<article class="flex border-b border-b-divider pb-4 gap-2 justify-between" project-id="{{ $project->id }}">
     <div class="flex gap-4">
         <img src="{{ $project->getCoverImagePath() }}" alt="Cover image" class="h-20 drop-shadow-xl" />
         <div class="flex justify-center flex-col">
@@ -9,7 +9,8 @@
         </div>
     </div>
     <div class="flex items-center justify-center flex-col-reverse">
-        <div class="flex gap-2">
+        <div class="flex gap-2 items-center">
+            <flux:icon icon="bars-3" class="mr-2 handle hover:cursor-pointer"></flux:icon>
             <flux:button iconLeading="pencil" href="{{ route('management.portfolio.edit', $project->slug) }}" class="hover:cursor-pointer"/>
             <livewire:projects.delete-project-button :project="$project" redirect-to="management.portfolio.index" :text="false"/>
         </div>

--- a/resources/views/livewire/projects/project-index.blade.php
+++ b/resources/views/livewire/projects/project-index.blade.php
@@ -4,10 +4,11 @@
             <flux:heading size="xl">Manage projects</flux:heading>
             <div class="flex gap-2">
                 <flux:button iconLeading="eye" href="{{ route('portfolio.index') }}" class="hover:cursor-pointer">View</flux:button>
+                <flux:button iconLeading="bookmark" onclick="saveOrder()" id="saveOrderButton" class="hover:cursor-pointer" disabled>Save Order</flux:button>
                 <flux:button iconLeading="plus" variant="primary" href="{{ route('management.portfolio.create') }}" class="hover:cursor-pointer">Add</flux:button>
             </div>
         </div>
-        <div class="space-y-6">
+        <div id="projects-container" class="space-y-6">
             @foreach($projects as $project)
                 <livewire:projects.project-cell :project="$project" />
             @endforeach
@@ -24,4 +25,38 @@
             </div>
         @endif
     </div>
+    <script src="https://SortableJS.github.io/Sortable/Sortable.js"></script>
+    <script>
+        let initialOrdering = getOrdering();
+
+        function getOrdering() {
+            return Array.from(document.getElementById('projects-container').children).map(function (projectElement) {
+                return parseInt(projectElement.getAttribute('project-id'));
+            });
+        }
+
+        function isInitialOrdering() {
+            return JSON.stringify(initialOrdering) === JSON.stringify(getOrdering());
+        }
+
+        function saveOrder() {
+            let ordering = getOrdering();
+            Livewire.dispatch('update-project-order', { ordering: ordering });
+            initialOrdering = ordering;
+            document.getElementById('saveOrderButton').setAttribute('disabled', '');
+        }
+
+        Sortable.create(document.getElementById('projects-container'), {
+            handle: '.handle',
+            animation: 200,
+            onEnd: function (_) {
+                let element = document.getElementById('saveOrderButton');
+                if (isInitialOrdering()) {
+                    element.setAttribute('disabled', '');
+                } else {
+                    element.removeAttribute('disabled');
+                }
+            }
+        });
+    </script>
 </div>

--- a/resources/views/livewire/projects/project-index.blade.php
+++ b/resources/views/livewire/projects/project-index.blade.php
@@ -3,7 +3,7 @@
         <div class="flex items-center justify-between gap-2 mb-4">
             <flux:heading size="xl">Manage projects</flux:heading>
             <div class="flex gap-2">
-                <flux:button iconLeading="eye" href="#" class="hover:cursor-pointer">View</flux:button>
+                <flux:button iconLeading="eye" href="{{ route('portfolio.index') }}" class="hover:cursor-pointer">View</flux:button>
                 <flux:button iconLeading="plus" variant="primary" href="{{ route('management.portfolio.create') }}" class="hover:cursor-pointer">Add</flux:button>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\IsAdminMiddleware;
 use App\Livewire\Blog\BlogIndex;
 use App\Livewire\Blog\ShowPost;
+use App\Livewire\Portfolio\PortfolioIndex;
 use App\Livewire\Posts\CreatePost;
 use App\Livewire\Posts\EditPost;
 use App\Livewire\Posts\PostIndex;
@@ -20,6 +21,8 @@ Route::get('/', function () {
 
 Route::get('blog', BlogIndex::class)->name('blog.index');
 Route::get('blog/{slug}', ShowPost::class)->name('blog.show');
+
+Route::get('portfolio', PortfolioIndex::class)->name('portfolio.index');
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');

--- a/tests/Feature/Portfolio/PortfolioIndexTest.php
+++ b/tests/Feature/Portfolio/PortfolioIndexTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Portfolio;
+
+use App\Livewire\Portfolio\PortfolioIndex;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PortfolioIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_a_successful_response(): void
+    {
+        $this->get('/portfolio')->assertSuccessful();
+    }
+
+    public function test_contains_portfolio_livewire_component(): void
+    {
+        $this->get('/portfolio')->assertSeeLivewire(PortfolioIndex::class);
+    }
+
+    public function test_can_see_projects(): void
+    {
+        Project::factory()->create(['title' => 'Test title']);
+        Project::factory()->create(['title' => 'Test title 2']);
+
+        $this->get('/portfolio')
+            ->assertSee('Test title')
+            ->assertSee('Test title 2');
+    }
+
+    public function test_can_see_all_project_info(): void
+    {
+        $project = Project::factory()->create([
+            'title' => 'Test title',
+            'tools' => 'Test tools',
+            'cover_img_filename' => 'cover-image.jpg',
+            'summary' => 'Test summary',
+            'repo_link' => 'https://test.link/'
+        ]);
+
+        $this->get('/portfolio')
+            ->assertSee('Test title')
+            ->assertSee('Test tools')
+            ->assertSeeHtml('src="' . $project->getCoverImagePath() . '"')
+            ->assertSee('Test summary')
+            ->assertSeeHtml('href="https://test.link/"');
+    }
+
+    public function test_projects_shown_in_order(): void
+    {
+        // Defaults to insertion order
+        Project::factory()->create(['title' => 'Test title']);
+        Project::factory()->create(['title' => 'Test title 2']);
+        Project::factory()->create(['title' => 'Test title 3']);
+
+        $this->get('/portfolio')
+            ->assertSeeInOrder(['Test title', 'Test title 2', 'Test title 3']);
+    }
+
+    public function test_guests_cannot_see_admin_panel(): void
+    {
+        $this->get('/portfolio')->assertDontSeeHtml('id="admin-panel"');
+    }
+
+    public function test_non_admin_users_cannot_see_admin_panel(): void
+    {
+        $this->actingAsUser();
+
+        $this->get('/portfolio')->assertDontSeeHtml('id="admin-panel"');
+    }
+
+    public function test_admins_can_see_admin_panel(): void
+    {
+        $this->actingAsAdmin();
+
+        $this->get('/portfolio')->assertSeeHtml('id="admin-panel"');
+    }
+}

--- a/tests/Feature/Projects/ProjectIndexTest.php
+++ b/tests/Feature/Projects/ProjectIndexTest.php
@@ -77,4 +77,18 @@ class ProjectIndexTest extends TestCase
         Livewire::test(ProjectIndex::class)->assertDontSeeLivewire(ProjectCell::class);
     }
 
+    public function test_update_to_ordering(): void
+    {
+        $this->actingAsAdmin();
+        Project::factory()->create(['title' => 'Test title 1']);
+        Project::factory()->create(['title' => 'Test title 2']);
+        Project::factory()->create(['title' => 'Test title 3']);
+
+        Livewire::test(ProjectIndex::class)
+            ->dispatch('update-project-order', [2, 3, 1]);
+
+        Livewire::test(ProjectIndex::class)
+            ->assertSeeInOrder(['Test title 2', 'Test title 3', 'Test title 1']);
+    }
+
 }


### PR DESCRIPTION
Implement portfolio page closing #14. Features: 

- The public portfolio page, featuring a Masonry
  - Cells show project title, summary, cover image, and a link to the repository
  - Standout projects are twice the size of standard ones
- Allow ordering to be changed in management section using SortableJS
- Add tests for the above