### PR TITLE
Implement closed source projects

### DIFF
--- a/app/Livewire/Projects/CreateProject.php
+++ b/app/Livewire/Projects/CreateProject.php
@@ -12,9 +12,10 @@ class CreateProject extends Component
 {
     use WithFileUploads;
 
-    public string $title, $slug, $tools, $summary, $coverImageFilename, $repoLink;
+    public string $title, $slug, $tools, $summary, $coverImageFilename;
+    public string|null $repoLink = null;
     public $coverImage;
-    public bool $standout;
+    public bool $openSource = true, $standout;
 
     protected $rules = [
         'title' => ['required', 'max:255'],
@@ -23,7 +24,7 @@ class CreateProject extends Component
         'coverImage' => ['required', 'image', 'max:1024'],
         'coverImageFilename' => ['required', 'unique:projects,cover_img_filename', 'max:255'],
         'summary' => ['required', 'max:255'],
-        'repoLink' => ['required', 'max:255', 'url']
+        'repoLink' => ['nullable', 'max:255', 'url']
     ];
 
     public function store(): void
@@ -31,6 +32,9 @@ class CreateProject extends Component
         $this->authorize('create', Project::class);
         $this->validate();
         try {
+            if (!$this->openSource) {
+                $this->repoLink = null;
+            }
             Project::writeCoverImage($this->coverImageFilename, $this->coverImage);
             Project::create([
                 'title' => $this->title,
@@ -44,7 +48,6 @@ class CreateProject extends Component
             $this->redirectRoute('management.portfolio.index');
         } catch (Throwable $th) {
             Log::error($th->getMessage());
-            $this->redirectRoute('management.portfolio.index');
             session()->flash('error', $th->getMessage());
         }
     }

--- a/app/Livewire/Projects/EditProject.php
+++ b/app/Livewire/Projects/EditProject.php
@@ -15,9 +15,10 @@ class EditProject extends Component
     use WithFileUploads;
 
     public Project $project;
-    public string $title, $slug, $tools, $summary, $coverImageFilename, $repoLink;
+    public string $title, $slug, $tools, $summary, $coverImageFilename;
+    public string|null $repoLink = null;
     public $coverImage;
-    public bool $standout;
+    public bool $openSource, $standout;
 
     protected $rules = [
         'title' => ['required', 'max:255'],
@@ -26,7 +27,7 @@ class EditProject extends Component
         'coverImage' => ['nullable', 'image', 'max:1024'],
         'coverImageFilename' => ['required', 'unique:projects,cover_img_filename', 'max:255'],
         'summary' => ['required', 'max:255'],
-        'repoLink' => ['required', 'max:255', 'url']
+        'repoLink' => ['nullable', 'max:255', 'url']
     ];
 
     public function mount(string $slug): void
@@ -41,6 +42,7 @@ class EditProject extends Component
         $this->tools = $this->project->tools;
         $this->summary = $this->project->summary;
         $this->coverImageFilename = $this->project->cover_img_filename;
+        $this->openSource = $this->project->repo_link != null;
         $this->repoLink = $this->project->repo_link;
         $this->standout = $this->project->standout == '1';
     }
@@ -50,6 +52,9 @@ class EditProject extends Component
         $this->authorize('update', $this->project);
         $this->validate($this->rules());
         try {
+            if (!$this->openSource) {
+                $this->repoLink = null;
+            }
             $this->project->updateCoverImage($this->coverImageFilename, $this->coverImage);
             $this->project->update([
                 'title' => $this->title,

--- a/database/migrations/2025_09_20_105752_make_repo_link_optional_in_projects_table.php
+++ b/database/migrations/2025_09_20_105752_make_repo_link_optional_in_projects_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->string('repo_link')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->string('repo_link')->change();
+        });
+    }
+};

--- a/resources/views/livewire/portfolio/portfolio-index.blade.php
+++ b/resources/views/livewire/portfolio/portfolio-index.blade.php
@@ -25,10 +25,14 @@
                     <article class="m-1 px-5 py-6 border border-divider rounded-lg">
                         <div class="flex justify-between items-center gap-2">
                             <flux:heading class="text-xl mb-0.5!">{{ $project->title }}</flux:heading>
-                            <a href="{{ $project->repo_link }}" target="_blank">
-                                <img src="/images/brands/github-mark.png" alt="GitHub Icon" class="h-6 dark:hidden" />
-                                <img src="/images/brands/github-mark-white.png" alt="GitHub Icon" class="h-6 hidden dark:block" />
-                            </a>
+                            @if($project->repo_link != null)
+                                <a href="{{ $project->repo_link }}" target="_blank">
+                                    <img src="/images/brands/github-mark.png" alt="GitHub Icon" class="h-6 dark:hidden" />
+                                    <img src="/images/brands/github-mark-white.png" alt="GitHub Icon" class="h-6 hidden dark:block" />
+                                </a>
+                            @else
+                                <flux:text size="sm" class="uppercase text-zinc-500">Closed source</flux:text>
+                            @endif
                         </div>
                         <flux:subheading size="md" class="mt-1.5 text-zinc-700 dark:text-zinc-50">{{ $project->summary }}</flux:subheading>
                         <img src="{{ $project->getCoverImagePath() }}" alt="Cover image" class="my-3 w-full"/>

--- a/resources/views/livewire/projects/create-project.blade.php
+++ b/resources/views/livewire/projects/create-project.blade.php
@@ -18,9 +18,16 @@
             </div>
         </div>
 
-        <flux:input wire:model="repoLink" :label="__('Repository Link')" type="text" />
+        <flux:checkbox wire:model="openSource" :label="__('Open Source')"/>
 
-        <flux:checkbox wire:model="standout" :label="__('Standout?')" />
+        <div wire:show="openSource">
+            <flux:input wire:model="repoLink" :label="__('Repository Link')" type="text" />
+        </div>
+
+        <div class="space-y-2">
+            <flux:checkbox wire:model="standout" :label="__('Standout')"/>
+            <flux:text>Standout projects are displayed on the home page and appear larger than standard projects on the portfolio page.</flux:text>
+        </div>
 
         <div class="flex items-center justify-between gap-2">
             <flux:button iconLeading="arrow-left" href="{{ route('management.portfolio.index') }}" class="hover:cursor-pointer">{{ __('Cancel') }}</flux:button>

--- a/resources/views/livewire/projects/edit-project.blade.php
+++ b/resources/views/livewire/projects/edit-project.blade.php
@@ -20,9 +20,16 @@
 
         <img src="{{ $project->getCoverImagePath() }}" alt="Cover image" class="w-50" />
 
-        <flux:input wire:model="repoLink" :label="__('Repository Link')" type="text" />
+        <flux:checkbox wire:model="openSource" :label="__('Open Source')"/>
 
-        <flux:checkbox wire:model="standout" :label="__('Standout?')" />
+        <div wire:show="openSource">
+            <flux:input wire:model="repoLink" :label="__('Repository Link')" type="text" />
+        </div>
+
+        <div class="space-y-2">
+            <flux:checkbox wire:model="standout" :label="__('Standout')"/>
+            <flux:text>Standout projects are displayed on the home page and appear larger than standard projects on the portfolio page.</flux:text>
+        </div>
 
         <div class="flex items-center justify-between gap-2">
             <div class="flex gap-2">

--- a/resources/views/livewire/projects/project-index.blade.php
+++ b/resources/views/livewire/projects/project-index.blade.php
@@ -10,7 +10,7 @@
         </div>
         <div id="projects-container" class="space-y-6">
             @foreach($projects as $project)
-                <livewire:projects.project-cell :project="$project" />
+                <livewire:projects.project-cell :project="$project" wire:key="project-cell-{{ $project->id }}" />
             @endforeach
         </div>
     </div>

--- a/tests/Feature/Projects/CreateProjectTest.php
+++ b/tests/Feature/Projects/CreateProjectTest.php
@@ -210,22 +210,6 @@ class CreateProjectTest extends TestCase
         $response->assertHasErrors('summary');
     }
 
-    public function test_cannot_create_project_without_repo_link(): void
-    {
-        $this->actingAsAdmin();
-
-        $response = Livewire::test(CreateProject::class)
-            ->set('title', 'Test Title')
-            ->set('slug', 'test-slug')
-            ->set('tools', 'Test languages')
-            ->set('coverImage', UploadedFile::fake()->image('test-img.png'))
-            ->set('coverImageFilename', 'test-img.png')
-            ->set('summary', 'Test summary')
-            ->call('store');
-
-        $response->assertHasErrors('repoLink');
-    }
-
     public function test_cannot_create_project_with_invalid_repo_link(): void
     {
         $this->actingAsAdmin();

--- a/tests/Feature/Projects/CreateProjectTest.php
+++ b/tests/Feature/Projects/CreateProjectTest.php
@@ -252,7 +252,35 @@ class CreateProjectTest extends TestCase
             'cover_img_filename' => 'test-img.png',
             'summary' => 'Test summary',
             'repo_link' => 'https://test.link/',
-            'standout' => 1
+            'standout' => true
+        ]);
+    }
+
+    public function test_repo_link_not_set_if_open_source_unchecked(): void
+    {
+        $this->actingAsAdmin();
+
+        $response = Livewire::test(CreateProject::class)
+            ->set('title', 'Test Title')
+            ->set('slug', 'test-slug')
+            ->set('tools', 'Test languages')
+            ->set('coverImage', UploadedFile::fake()->image('test-img.png'))
+            ->set('coverImageFilename', 'test-img.png')
+            ->set('summary', 'Test summary')
+            ->set('repoLink', 'https://test.link/')
+            ->set('openSource', false)
+            ->call('store');
+
+        $response->assertHasNoErrors();
+
+        $this->assertDatabaseHas('projects', [
+            'title' => 'Test Title',
+            'slug' => 'test-slug',
+            'tools' => 'Test languages',
+            'cover_img_filename' => 'test-img.png',
+            'summary' => 'Test summary',
+            'repo_link' => null,
+            'standout' => false
         ]);
     }
 

--- a/tests/Feature/Projects/EditProjectTest.php
+++ b/tests/Feature/Projects/EditProjectTest.php
@@ -234,7 +234,36 @@ class EditProjectTest extends TestCase
             'cover_img_filename' => 'new-test-img.png',
             'summary' => 'New test summary',
             'repo_link' => 'https://test.link/new',
-            'standout' => 0
+            'standout' => false
+        ]);
+    }
+
+    public function test_repo_link_removed_when_open_source_unchecked(): void
+    {
+        $this->actingAsAdmin();
+        $project = Project::factory()->create([
+            'title' => 'Test Title',
+            'slug' => 'test-slug',
+            'tools' => 'Test languages',
+            'cover_img_filename' => 'test-img.png',
+            'summary' => 'Test Summary',
+            'repo_link' => 'https://test.link/',
+            'standout' => false
+        ]);
+
+        Livewire::test(EditProject::class, ['slug' => $project->slug])
+            ->set('openSource', false)
+            ->call('update')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('projects', [
+            'title' => 'Test Title',
+            'slug' => 'test-slug',
+            'tools' => 'Test languages',
+            'cover_img_filename' => 'test-img.png',
+            'summary' => 'Test Summary',
+            'repo_link' => null,
+            'standout' => false
         ]);
     }
 

--- a/tests/Feature/Projects/EditProjectTest.php
+++ b/tests/Feature/Projects/EditProjectTest.php
@@ -190,18 +190,6 @@ class EditProjectTest extends TestCase
         $response->assertHasErrors('summary');
     }
 
-    public function test_cannot_remove_repo_link(): void
-    {
-        $this->actingAsAdmin();
-        $project = Project::factory()->create(['slug' => 'test-slug']);
-
-        $response = Livewire::test(EditProject::class, ['slug' => $project->slug])
-            ->set('repoLink', '')
-            ->call('update');
-
-        $response->assertHasErrors('repoLink');
-    }
-
     public function test_cannot_change_to_invalid_repo_link(): void
     {
         $this->actingAsAdmin();


### PR DESCRIPTION
Implement closed source projects closing #19. Changes: 

- Added database migration making repository link nullable
- Make repository link nullable in create/edit project pages 
- Add a checkbox in create/edit project pages which shows/hides repo link
- Display 'closed source' in place of the GitHub link on the portfolio page when a project is closed source
- Update tests to reflect the above